### PR TITLE
Add save_as_dot for logic circuits

### DIFF
--- a/src/IO/CircuitSaver.jl
+++ b/src/IO/CircuitSaver.jl
@@ -104,10 +104,10 @@ end
 save_circuit(name::String, circuit::StructLogicalΔ, vtree::PlainVtree) = save_sdd_file(name, circuit, vtree)
 
 "Rank nodes in the same layer left to right"
-function get_nodes_level(circuit::LogicalΔ)
-    levels = Vector{Vector{LogicalΔNode}}()
-    current = Vector{LogicalΔNode}()
-    next = Vector{LogicalΔNode}()
+function get_nodes_level(circuit::Δ)
+    levels = Vector{Vector{ΔNode}}()
+    current = Vector{ΔNode}()
+    next = Vector{ΔNode}()
 
     push!(next, circuit[end])
     push!(levels, Base.copy(next))
@@ -115,7 +115,7 @@ function get_nodes_level(circuit::LogicalΔ)
         current, next = next, current
         while !isempty(current)
             n = popfirst!(current)
-            if n isa Logical.LogicalInnerNode
+            if isinner(n)
                 for c in children(n)
                     if !(c in next) push!(next, c); end
                 end
@@ -128,12 +128,10 @@ function get_nodes_level(circuit::LogicalΔ)
 end
 
 function save_as_dot(root::LogicalΔNode, file::String)
-  circuit = Vector{LogicalΔNode}()
-  foreach(x -> pushfirst!(circuit, x), root)
-  return save_as_dot(circuit, file)
+    return save_as_dot(node2dag(root), file)
 end
 
-"Save prob circuits to .dot file"
+"Save logic circuit to .dot file"
 function save_as_dot(circuit::LogicalΔ, file::String)
     node_cache = Dict{LogicalΔNode, Int64}()
     for (i, n) in enumerate(circuit)

--- a/test/IO/CircuitSaverTest.jl
+++ b/test/IO/CircuitSaverTest.jl
@@ -3,11 +3,29 @@ using LogicCircuits
 
 @testset "Circuit saver tests" begin
 
-  circuit, vtree = load_struct_smooth_logical_circuit(zoo_lc_file("mnist-large.circuit"), zoo_vtree_file("balanced.vtree"))
-
   mktempdir() do tmp
+    circuit, vtree = load_struct_smooth_logical_circuit(zoo_lc_file("mnist-large.circuit"), zoo_vtree_file("balanced.vtree"))
     # the circuit above does not conform the the SDD requirements
     @test_throws Exception save_circuit("$tmp/temp.sdd", circuit, vtree)
+  end
+
+  mktempdir() do tmp
+    lin = LogicalΔNode[]
+    ors = map(1:10) do v
+        pos = LiteralNode(var2lit(Var(v)))
+        push!(lin, pos)
+        neg = LiteralNode(-var2lit(Var(v)))
+        push!(lin, neg)
+        or = ⋁Node([pos,neg])
+        push!(lin, or)
+        or
+    end
+    and = ⋀Node(ors)
+    push!(lin, and)
+    bias = ⋁Node([and])
+    push!(lin, bias)
+    @test_nowarn save_as_dot(lin, "$tmp/temp.dot")
+    @test_nowarn save_as_dot(lin[end], "$tmp/temp.dot")
   end
 
   # TODO add a test to load and save and load an .sdd file


### PR DESCRIPTION
The function `save_as_dot` is defined in `src/IO/IO.jl`, but not implemented. This patch simply adapts the equivalent function `save_as_dot` defined in `ProbabilisticCircuits` (https://github.com/Juice-jl/ProbabilisticCircuits.jl/blob/master/src/IO/CircuitSaver.jl) but for `LogicCircuits`.

Obviously this isn't the best approach to solving this issue, as ideally we should have these two `save_as_dot` functions call some other more general function. But this would require changing how nodes are printed (perhaps adding a `printdot` method for each node and simply calling it instead of having two different `save_as_dot` functions with a bunch of `if` and `else`s?) or changing how nodes are typed (in the sense disjunction and conjunction nodes would have a common ancestor, e.g. `\bigveeNode` and `Prob\bigveeNode` would be subtypes of `DisjunctionNode` or whatever).

There is another flaw to this implementation as well: structured nodes are unsupported. Since I'm only working (so far) with the regular `Logical\DeltaNode`s, and I'm not so familiar with this library yet, I'm choosing to keep it the way it is for now.

Added a test case for the function as well. Not sure the right way of doing it, so will be happy to fix if needed.