### PR TITLE
Add save_as_tex for TikZ circuit saving

### DIFF
--- a/src/LoadSave/circuit_savers.jl
+++ b/src/LoadSave/circuit_savers.jl
@@ -1,4 +1,4 @@
-export save_as_dot, save_circuit, save_as_sdd, save_as_tex
+export save_as_dot, save_circuit, save_as_sdd, save_as_tex, save_as_dot2tex
 
 #####################
 # Save lines
@@ -125,6 +125,34 @@ function get_nodes_level(circuit::Node)
     return levels
 end
 
+"""Effectively returns the inverse of `get_nodes_level`, returning a dictionary where keys are the
+nodes and values are their levels, and the highest level in the circuit."""
+function get_level_nodes(circuit::LogicCircuit)::Tuple{Dict{LogicCircuit, Int}, Int}
+    levels = Dict{LogicCircuit, Int}()
+    current = Vector{Node}()
+    next = Vector{Node}()
+
+    push!(next, circuit)
+    i = 1
+    while !isempty(next)
+        current, next = next, current
+        while !isempty(current)
+            n = popfirst!(current)
+            if isinner(n)
+                for c in children(n)
+                    if c ∉ next
+                        push!(next, c)
+                        levels[c] = i
+                    end
+                end
+            end
+        end
+        i += 1
+    end
+
+    return levels, i
+end
+
 "Save logic circuit to .dot file"
 function save_as_dot(circuit::LogicCircuit, file::String)
     circuit_nodes = linearize(circuit)
@@ -180,7 +208,7 @@ function save_as_dot(circuit::LogicCircuit, file::String)
     close(f)
 end
 
-"""Save logic circuit as a LaTeX TikZ .tex file.
+"""Save logic circuit as a LaTeX TikZ .tex file using the dot2tex engine.
 
 Argument `V` is a label map for each vertex; `E` is a label map for each edge; `⋀_style`,
 `⋁_style`, `lit_style`, `⊤_style`, and `⊥_style` are styles for each node type; `edge_turn` is how
@@ -190,7 +218,7 @@ terminal nodes.
 Note: `save_as_tex` does not work well on large circuits, and the resulting LaTeX file should serve
 as a first sketch in (serious) need for adjustments.
 """
-function save_as_tex(circuit::LogicCircuit, file::String,
+function save_as_dot2tex(circuit::LogicCircuit, file::String,
                      V::Dict{LogicCircuit, Any} = Dict{LogicCircuit, Any}(),
                      E::Dict{Tuple{LogicCircuit, Int}, Any} = Dict{Tuple{LogicCircuit, Int}, Any}(),
                      ⋀_style::String = "and gate,fill=blue!50!red!30",
@@ -298,6 +326,129 @@ function save_as_tex(circuit::LogicCircuit, file::String,
                 l = label(N, i)
                 write(f, draw_edge(N_id, C_id, i, m, isempty(l) ? "" : "node {\\small $l}"))
             end
+        end
+    end
+
+    write(f, postamble)
+    flush(f)
+    close(f)
+end
+
+"""Save logic circuit as a LaTeX TikZ .tex file.
+Argument `V` is a label map for each vertex, `E` is a label map for each edge, `⋀_style` is the
+TikZ conjunction node style to use, `⋁_style` is the TikZ disjunction node style to use,
+`node_ysep` is the y-axis separation distance for nodes, `node_xsep` for the x-axis, `edge_turn` is
+how far down should edges "bend", `verbose` if set to true prints comments to the LaTeX file for
+better readability.
+
+Note: `save_as_tex` does not work well on large circuits, and the resulting LaTeX file should serve
+as a first sketch in (serious) need for adjustments.
+"""
+function save_as_tex(circuit::LogicCircuit, file::String,
+                     V::Dict{LogicCircuit, Any} = Dict{LogicCircuit, Any}(),
+                     E::Dict{Tuple{LogicCircuit, Int}, Any} = Dict{Tuple{LogicCircuit, Int}, Any}(),
+                     ⋀_style::String = "and gate,fill=blue!50!red!30",
+                     ⋁_style::String = "or gate,fill=blue!50!green!30",
+                     node_ysep::Float64 = 1.25, node_xsep::Float64 = 1.0, edge_turn::Float64 = 0.25,
+                     verbose::Bool = false)
+    preamble = """
+    \\documentclass{standalone}
+
+    \\usepackage{mathtools}
+    \\usepackage{amssymb}
+    \\usepackage{amsfonts}
+    \\usepackage{tikz}
+    \\usepackage{xcolor}
+    \\usetikzlibrary{shapes,arrows,positioning,fit,circuits.logic.US}
+
+    \\newcommand{\\andNode}[4]{\\node[style={thick},#4,$(⋀_style)] (#1) at #2 {\\rotatebox{-90}{#3}}}
+    \\newcommand{\\orNode}[4]{\\node[style={thick},#4,$(⋁_style)] (#1) at #2 {\\rotatebox{-90}{#3}}}
+
+    \\begin{document}
+
+    \\begin{tikzpicture}[circuit logic US,every circuit symbol/.style={thick,point up}]
+    """
+    postamble = """
+    \\end{tikzpicture}
+    \\end{document}
+    """
+
+    nodes = linearize(circuit)
+    cache = Dict{LogicCircuit, Int}()
+    for (i, n) in enumerate(nodes) cache[n] = i end
+    L, max_level = get_level_nodes(circuit)
+
+    function label(v::LogicCircuit)::String
+        if haskey(V, v)
+            return string(V[v])
+        elseif isleaf(v)
+            if isliteralgate(v)
+                l = literal(v)
+                return l < 0 ? "\$\\neg $(-l)\$" : "\$$l\$"
+            end
+            return istrue(v) ? "\$\\top\$" : "\$\\bot\$"
+        end
+        return ""
+    end
+    label(v::LogicCircuit, c::Int)::String = (e = (v, c); haskey(E, e) ? string(E[e]) : "")
+
+    compute_xsep(m::Int, i::Int, sep::Float64, l::Int)::String = string(((max_level-l)*sep)*(i-1-((m-1)/2)))
+    compute_edge_turn(m::Int, i::Int)::String = string(-edge_turn*(0.75*m-abs((m+1)/2 - i)))
+
+    # Draws a TikZ root logical node. Arguments are: node type `t`, number of children `n`,
+    # node ID `id`, and node label.
+    root_tikz(t::String, n::Int, id::Int, label::String)::String =
+        "  \\$(t)Node{n$id}{(0,0)}{$label}{inputs=$('n'^n)};\n"
+
+    # Draws a TikZ inner logical node. Arguments are: node type `t`, number of children `n`, node
+    # ID `id`, parent node ID `pid`, number of siblings `m`, child index `c`, node level `l`, and
+    # node label.
+    inner_tikz(t::String, n::Int, id::Int, pid::Int, m::Int, c::Int, l::Int, label::String)::String =
+        "  \\$(t)Node{n$id}{(\$(n$pid.input $c) + ($(compute_xsep(m, c, node_xsep, l)),-$node_ysep)\$)}{$label}{inputs=$('n'^n)};\n"
+
+    # Draws a TikZ leaf node. Arguments are: node ID `id`, parent node ID `pid`, number of siblings
+    # `n`, child index `c`, and a terminal label.
+    leaf_tikz(id::Int, pid::Int, m::Int, c::Int, label::String)::String =
+        "  \\node (n$id) at (\$(n$pid.input $c) + ($(compute_xsep(m, c, node_xsep/2, max_level-1)),-$(node_ysep/2))\$) {$label};\n"
+
+    # Draws a TikZ edge. Arguments are: outgoing edge node ID `pid`, incoming edge node ID `cid`,
+    # number of "sibling" edges `m`, child index `c`, and edge label.
+    edge_tikz(pid::Int, cid::Int, m::Int, c::Int, label::String)::String =
+        (l = isempty(label) ? "" : "node {\\small $label}";
+         "  \\draw (n$pid.input $c) -- ++(0,$(compute_edge_turn(m, c))) -| $l (n$cid);\n")
+
+    inner_rep(N::LogicCircuit)::String = is⋀gate(N) ? "and" : "or"
+
+    f = open(file, "w")
+
+    write(f, preamble)
+
+    Q = LogicCircuit[circuit]
+    U = Dict{LogicCircuit, Bool}(circuit => true)
+    first = true
+    while !isempty(Q)
+        N = popfirst!(Q)
+        N_id = cache[N]
+        m = num_children(N)
+        if first
+            verbose && write(f, "  % Root of circuit with ID: $N_id\n")
+            write(f, root_tikz(inner_rep(N), m, N_id, label(N)))
+            first = false
+        end
+        for (i, C) in enumerate(children(N))
+            if haskey(U, C) continue end
+            C_id = cache[C]
+            if isleaf(C)
+                verbose && write(f, "  % Leaf node with ID: $C_id, child of $N_id\n")
+                write(f, leaf_tikz(C_id, N_id, m, i, label(C)))
+            else
+                t = inner_rep(C)
+                verbose && write(f, "  % Inner node ($t gate) with ID: $C_id, child of $N_id\n")
+                write(f, inner_tikz(t, num_children(C), C_id, N_id, m, i, L[C], label(C)))
+                push!(Q, C); U[C] = true
+            end
+            verbose && write(f, "  % Edge from $N_id to $C_id\n")
+            write(f, edge_tikz(N_id, C_id, m, i, label(N, i)))
         end
     end
 

--- a/src/LoadSave/circuit_savers.jl
+++ b/src/LoadSave/circuit_savers.jl
@@ -125,34 +125,6 @@ function get_nodes_level(circuit::Node)
     return levels
 end
 
-"""Effectively returns the inverse of `get_nodes_level`, returning a dictionary where keys are the
-nodes and values are their levels, and the highest level in the circuit."""
-function get_level_nodes(circuit::LogicCircuit)::Tuple{Dict{LogicCircuit, Int}, Int}
-    levels = Dict{LogicCircuit, Int}()
-    current = Vector{Node}()
-    next = Vector{Node}()
-
-    push!(next, circuit)
-    i = 1
-    while !isempty(next)
-        current, next = next, current
-        while !isempty(current)
-            n = popfirst!(current)
-            if isinner(n)
-                for c in children(n)
-                    if c ∉ next
-                        push!(next, c)
-                        levels[c] = i
-                    end
-                end
-            end
-        end
-        i += 1
-    end
-
-    return levels, i
-end
-
 "Save logic circuit to .dot file"
 function save_as_dot(circuit::LogicCircuit, file::String)
     circuit_nodes = linearize(circuit)
@@ -209,11 +181,11 @@ function save_as_dot(circuit::LogicCircuit, file::String)
 end
 
 """Save logic circuit as a LaTeX TikZ .tex file.
-Argument `V` is a label map for each vertex, `E` is a label map for each edge, `⋀_style` is the
-TikZ conjunction node style to use, `⋁_style` is the TikZ disjunction node style to use,
-`node_ysep` is the y-axis separation distance for nodes, `node_xsep` for the x-axis, `edge_turn` is
-how far down should edges "bend", `verbose` if set to true prints comments to the LaTeX file for
-better readability.
+
+Argument `V` is a label map for each vertex; `E` is a label map for each edge; `⋀_style`,
+`⋁_style`, `lit_style`, `⊤_style`, and `⊥_style` are styles for each node type; `edge_turn` is how
+far down should edges "bend"; `node_xsep` and `node_ysep` are x and y-axis separation sizes for
+terminal nodes.
 
 Note: `save_as_tex` does not work well on large circuits, and the resulting LaTeX file should serve
 as a first sketch in (serious) need for adjustments.
@@ -223,25 +195,33 @@ function save_as_tex(circuit::LogicCircuit, file::String,
                      E::Dict{Tuple{LogicCircuit, Int}, Any} = Dict{Tuple{LogicCircuit, Int}, Any}(),
                      ⋀_style::String = "and gate,fill=blue!50!red!30",
                      ⋁_style::String = "or gate,fill=blue!50!green!30",
-                     node_ysep::Float64 = 1.25, node_xsep::Float64 = 1.0, edge_turn::Float64 = 0.25,
-                     verbose::Bool = false)
+                     ⊤_style::String = "", ⊥_style::String = "", lit_style::String = "",
+                     edge_turn::Float64 = 0.25, ortho_splines::Bool = true,
+                     node_xsep::Float64 = 1.0, node_ysep::Float64 = 1.25)
     preamble = """
     \\documentclass{standalone}
 
-    \\usepackage{amsmath}
     \\usepackage{mathtools}
     \\usepackage{amssymb}
     \\usepackage{amsfonts}
     \\usepackage{tikz}
     \\usepackage{xcolor}
+    \\usepackage{dot2texi}
     \\usetikzlibrary{shapes,arrows,positioning,fit,circuits.logic.US}
-
-    \\newcommand{\\andNode}[4]{\\node[style={thick},#4,$(⋀_style)] (#1) at #2 {\\rotatebox{-90}{#3}}}
-    \\newcommand{\\orNode}[4]{\\node[style={thick},#4,$(⋁_style)] (#1) at #2 {\\rotatebox{-90}{#3}}}
 
     \\begin{document}
 
-    \\begin{tikzpicture}[circuit logic US,every circuit symbol/.style={thick,point up}]
+    \\begin{tikzpicture}[>=latex',circuit logic US,every circuit symbol/.style={thick,point up}]
+        \\tikzstyle{and} = [$(⋀_style)]
+        \\tikzstyle{or} = [$(⋁_style)]
+        \\tikzstyle{top} = [$(⊤_style)]
+        \\tikzstyle{bot} = [$(⊥_style)]
+        \\tikzstyle{lit} = [$(lit_style)]
+        \\begin{dot2tex}[dot,tikz,codeonly,styleonly,options=-s -tmath]
+            digraph G {
+                graph [pad="0.75", ranksep="0.25", nodesep="0.25"];
+                node [label=""];
+                $(ortho_splines ? "edge [style=\"invis\"];" : "")
     """
     postamble = """
     \\end{tikzpicture}
@@ -251,7 +231,7 @@ function save_as_tex(circuit::LogicCircuit, file::String,
     nodes = linearize(circuit)
     cache = Dict{LogicCircuit, Int}()
     for (i, n) in enumerate(nodes) cache[n] = i end
-    L, max_level = get_level_nodes(circuit)
+    L = get_nodes_level(circuit)
 
     function label(v::LogicCircuit)::String
         if haskey(V, v)
@@ -266,64 +246,58 @@ function save_as_tex(circuit::LogicCircuit, file::String,
         return ""
     end
     label(v::LogicCircuit, c::Int)::String = (e = (v, c); haskey(E, e) ? string(E[e]) : "")
-
-    compute_xsep(m::Int, i::Int, sep::Float64, l::Int)::String = string(((max_level-l)*sep)*(i-1-((m-1)/2)))
+    compute_xsep(m::Int, i::Int, sep::Float64)::String = string(sep*(i-1-((m-1)/2)))
     compute_edge_turn(m::Int, i::Int)::String = string(-edge_turn*(0.75*m-abs((m+1)/2 - i)))
-
-    # Draws a TikZ root logical node. Arguments are: node type `t`, number of children `n`,
-    # node ID `id`, and node label.
-    root_tikz(t::String, n::Int, id::Int, label::String)::String =
-        "  \\$(t)Node{n$id}{(0,0)}{$label}{inputs=$('n'^n)};\n"
-
-    # Draws a TikZ inner logical node. Arguments are: node type `t`, number of children `n`, node
-    # ID `id`, parent node ID `pid`, number of siblings `m`, child index `c`, node level `l`, and
-    # node label.
-    inner_tikz(t::String, n::Int, id::Int, pid::Int, m::Int, c::Int, l::Int, label::String)::String =
-        "  \\$(t)Node{n$id}{(\$(n$pid.input $c) + ($(compute_xsep(m, c, node_xsep, l)),-$node_ysep)\$)}{$label}{inputs=$('n'^n)};\n"
-
-    # Draws a TikZ leaf node. Arguments are: node ID `id`, parent node ID `pid`, number of siblings
-    # `n`, child index `c`, and a terminal label.
+    draw_edge(pid::Int, cid::Int, c::Int, m::Int, l::String)::String =
+        "    \\draw (n$pid.input $c) -- ++(0,$(compute_edge_turn(m, c))) -| $l (n$cid);\n"
+    leaf_type(t::LogicCircuit)::String = istrue(t) ? "top" : isfalse(t) ? "bot" : "lit"
     leaf_tikz(id::Int, pid::Int, m::Int, c::Int, label::String)::String =
-        "  \\node (n$id) at (\$(n$pid.input $c) + ($(compute_xsep(m, c, node_xsep/2, max_level-1)),-$(node_ysep/2))\$) {$label};\n"
-
-    # Draws a TikZ edge. Arguments are: outgoing edge node ID `pid`, incoming edge node ID `cid`,
-    # number of "sibling" edges `m`, child index `c`, and edge label.
-    edge_tikz(pid::Int, cid::Int, m::Int, c::Int, label::String)::String =
-        (l = isempty(label) ? "" : "node {\\small $label}";
-         "  \\draw (n$pid.input $c) -- ++(0,$(compute_edge_turn(m, c))) -| $l (n$cid);\n")
-
-    inner_rep(N::LogicCircuit)::String = is⋀gate(N) ? "and" : "or"
+        "    \\node (n$id) at (\$(n$pid.input $c) + ($(compute_xsep(m, c, node_xsep/2)),-$(node_ysep/2))\$) {$label};\n"
 
     f = open(file, "w")
-
     write(f, preamble)
 
-    Q = LogicCircuit[circuit]
-    U = Dict{LogicCircuit, Bool}(circuit => true)
-    first = true
-    while !isempty(Q)
-        N = popfirst!(Q)
-        N_id = cache[N]
-        m = num_children(N)
-        if first
-            verbose && write(f, "  % Root of circuit with ID: $N_id\n")
-            write(f, root_tikz(inner_rep(N), m, N_id, label(N)))
-            first = false
+    # Define nodes, except leaves which are treated as a special case.
+    for N in Iterators.reverse(nodes)
+        if isinner(N)
+            write(f, "            n$(cache[N]) [style=\"$(is⋀gate(N) ? "and" : "or"),inputs=$('n'^num_children(N))\", label=\"$(label(N))\"];\n")
         end
-        for (i, C) in enumerate(children(N))
-            if haskey(U, C) continue end
-            C_id = cache[C]
-            if isleaf(C)
-                verbose && write(f, "  % Leaf node with ID: $C_id, child of $N_id\n")
-                write(f, leaf_tikz(C_id, N_id, m, i, label(C)))
-            else
-                t = inner_rep(C)
-                verbose && write(f, "  % Inner node ($t gate) with ID: $C_id, child of $N_id\n")
-                write(f, inner_tikz(t, num_children(C), C_id, N_id, m, i, L[C], label(C)))
-                push!(Q, C); U[C] = true
+    end
+
+    # Write ranks.
+    for l in L
+        if length(l) > 1
+            write(f, "            {rank=\"same\";newrank=\"true\";rankdir=\"LR\";")
+            rank = ""
+            foreach(x -> rank *= "n$(cache[x])->", l)
+            rank = rank[1:end-2]
+            write(f, rank)
+            write(f, "[style=\"invis\"]}\n")
+        end
+    end
+
+    # Draw "invisible" edges top-down to force layout.
+    for N in Iterators.reverse(nodes)
+        if isleaf(N) continue end
+        for C in children(N)
+            write(f, "            n$(cache[N]) -> n$(cache[C]);\n")
+        end
+    end
+
+    write(f, "        }\n    \\end{dot2tex}\n")
+
+    # Draw actual edges and terminal nodes.
+    if ortho_splines
+        for N in Iterators.reverse(nodes)
+            if isleaf(N) continue end
+            N_id = cache[N]
+            m = num_children(N)
+            for (i, C) in enumerate(children(N))
+                C_id = cache[C]
+                if isleaf(C) write(f, leaf_tikz(C_id, N_id, m, i, label(C))) end
+                l = label(N, i)
+                write(f, draw_edge(N_id, C_id, i, m, isempty(l) ? "" : "node {\\small $l}"))
             end
-            verbose && write(f, "  % Edge from $N_id to $C_id\n")
-            write(f, edge_tikz(N_id, C_id, m, i, label(N, i)))
         end
     end
 

--- a/src/LoadSave/circuit_savers.jl
+++ b/src/LoadSave/circuit_savers.jl
@@ -1,4 +1,4 @@
-export save_as_dot, save_circuit, save_as_sdd
+export save_as_dot, save_circuit, save_as_sdd, save_as_tex
 
 #####################
 # Save lines
@@ -125,6 +125,34 @@ function get_nodes_level(circuit::Node)
     return levels
 end
 
+"""Effectively returns the inverse of `get_nodes_level`, returning a dictionary where keys are the
+nodes and values are their levels, and the highest level in the circuit."""
+function get_level_nodes(circuit::LogicCircuit)::Tuple{Dict{LogicCircuit, Int}, Int}
+    levels = Dict{LogicCircuit, Int}()
+    current = Vector{Node}()
+    next = Vector{Node}()
+
+    push!(next, circuit)
+    i = 1
+    while !isempty(next)
+        current, next = next, current
+        while !isempty(current)
+            n = popfirst!(current)
+            if isinner(n)
+                for c in children(n)
+                    if c ∉ next
+                        push!(next, c)
+                        levels[c] = i
+                    end
+                end
+            end
+        end
+        i += 1
+    end
+
+    return levels, i
+end
+
 "Save logic circuit to .dot file"
 function save_as_dot(circuit::LogicCircuit, file::String)
     circuit_nodes = linearize(circuit)
@@ -176,6 +204,130 @@ function save_as_dot(circuit::LogicCircuit, file::String)
     end
 
     write(f, "}\n")
+    flush(f)
+    close(f)
+end
+
+"""Save logic circuit as a LaTeX TikZ .tex file.
+Argument `V` is a label map for each vertex, `E` is a label map for each edge, `⋀_style` is the
+TikZ conjunction node style to use, `⋁_style` is the TikZ disjunction node style to use,
+`node_ysep` is the y-axis separation distance for nodes, `node_xsep` for the x-axis, `edge_turn` is
+how far down should edges "bend", `verbose` if set to true prints comments to the LaTeX file for
+better readability.
+
+Note: `save_as_tex` does not work well on large circuits, and the resulting LaTeX file should serve
+as a first sketch in (serious) need for adjustments.
+"""
+function save_as_tex(circuit::LogicCircuit, file::String,
+                     V::Dict{LogicCircuit, Any} = Dict{LogicCircuit, Any}(),
+                     E::Dict{Tuple{LogicCircuit, Int}, Any} = Dict{Tuple{LogicCircuit, Int}, Any}(),
+                     ⋀_style::String = "and gate,fill=blue!50!red!30",
+                     ⋁_style::String = "or gate,fill=blue!50!green!30",
+                     node_ysep::Float64 = 1.25, node_xsep::Float64 = 1.0, edge_turn::Float64 = 0.25,
+                     verbose::Bool = false)
+    preamble = """
+    \\documentclass{standalone}
+
+    \\usepackage{amsmath}
+    \\usepackage{mathtools}
+    \\usepackage{amssymb}
+    \\usepackage{amsfonts}
+    \\usepackage{tikz}
+    \\usepackage{xcolor}
+    \\usetikzlibrary{shapes,arrows,positioning,fit,circuits.logic.US}
+
+    \\newcommand{\\andNode}[4]{\\node[style={thick},#4,$(⋀_style)] (#1) at #2 {\\rotatebox{-90}{#3}}}
+    \\newcommand{\\orNode}[4]{\\node[style={thick},#4,$(⋁_style)] (#1) at #2 {\\rotatebox{-90}{#3}}}
+
+    \\begin{document}
+
+    \\begin{tikzpicture}[circuit logic US,every circuit symbol/.style={thick,point up}]
+    """
+    postamble = """
+    \\end{tikzpicture}
+    \\end{document}
+    """
+
+    nodes = linearize(circuit)
+    cache = Dict{LogicCircuit, Int}()
+    for (i, n) in enumerate(nodes) cache[n] = i end
+    L, max_level = get_level_nodes(circuit)
+
+    function label(v::LogicCircuit)::String
+        if haskey(V, v)
+            return string(V[v])
+        elseif isleaf(v)
+            if isliteralgate(v)
+                l = literal(v)
+                return l < 0 ? "\$\\neg $(-l)\$" : "\$$l\$"
+            end
+            return istrue(v) ? "\$\\top\$" : "\$\\bot\$"
+        end
+        return ""
+    end
+    label(v::LogicCircuit, c::Int)::String = (e = (v, c); haskey(E, e) ? string(E[e]) : "")
+
+    compute_xsep(m::Int, i::Int, sep::Float64, l::Int)::String = string(((max_level-l)*sep)*(i-1-((m-1)/2)))
+    compute_edge_turn(m::Int, i::Int)::String = string(-edge_turn*(0.75*m-abs((m+1)/2 - i)))
+
+    # Draws a TikZ root logical node. Arguments are: node type `t`, number of children `n`,
+    # node ID `id`, and node label.
+    root_tikz(t::String, n::Int, id::Int, label::String)::String =
+        "  \\$(t)Node{n$id}{(0,0)}{$label}{inputs=$('n'^n)};\n"
+
+    # Draws a TikZ inner logical node. Arguments are: node type `t`, number of children `n`, node
+    # ID `id`, parent node ID `pid`, number of siblings `m`, child index `c`, node level `l`, and
+    # node label.
+    inner_tikz(t::String, n::Int, id::Int, pid::Int, m::Int, c::Int, l::Int, label::String)::String =
+        "  \\$(t)Node{n$id}{(\$(n$pid.input $c) + ($(compute_xsep(m, c, node_xsep, l)),-$node_ysep)\$)}{$label}{inputs=$('n'^n)};\n"
+
+    # Draws a TikZ leaf node. Arguments are: node ID `id`, parent node ID `pid`, number of siblings
+    # `n`, child index `c`, and a terminal label.
+    leaf_tikz(id::Int, pid::Int, m::Int, c::Int, label::String)::String =
+        "  \\node (n$id) at (\$(n$pid.input $c) + ($(compute_xsep(m, c, node_xsep/2, max_level-1)),-$(node_ysep/2))\$) {$label};\n"
+
+    # Draws a TikZ edge. Arguments are: outgoing edge node ID `pid`, incoming edge node ID `cid`,
+    # number of "sibling" edges `m`, child index `c`, and edge label.
+    edge_tikz(pid::Int, cid::Int, m::Int, c::Int, label::String)::String =
+        (l = isempty(label) ? "" : "node {\\small $label}";
+         "  \\draw (n$pid.input $c) -- ++(0,$(compute_edge_turn(m, c))) -| $l (n$cid);\n")
+
+    inner_rep(N::LogicCircuit)::String = is⋀gate(N) ? "and" : "or"
+
+    f = open(file, "w")
+
+    write(f, preamble)
+
+    Q = LogicCircuit[circuit]
+    U = Dict{LogicCircuit, Bool}(circuit => true)
+    first = true
+    while !isempty(Q)
+        N = popfirst!(Q)
+        N_id = cache[N]
+        m = num_children(N)
+        if first
+            verbose && write(f, "  % Root of circuit with ID: $N_id\n")
+            write(f, root_tikz(inner_rep(N), m, N_id, label(N)))
+            first = false
+        end
+        for (i, C) in enumerate(children(N))
+            if haskey(U, C) continue end
+            C_id = cache[C]
+            if isleaf(C)
+                verbose && write(f, "  % Leaf node with ID: $C_id, child of $N_id\n")
+                write(f, leaf_tikz(C_id, N_id, m, i, label(C)))
+            else
+                t = inner_rep(C)
+                verbose && write(f, "  % Inner node ($t gate) with ID: $C_id, child of $N_id\n")
+                write(f, inner_tikz(t, num_children(C), C_id, N_id, m, i, L[C], label(C)))
+                push!(Q, C); U[C] = true
+            end
+            verbose && write(f, "  % Edge from $N_id to $C_id\n")
+            write(f, edge_tikz(N_id, C_id, m, i, label(N, i)))
+        end
+    end
+
+    write(f, postamble)
     flush(f)
     close(f)
 end

--- a/test/LoadSave/circuit_saver_test.jl
+++ b/test/LoadSave/circuit_saver_test.jl
@@ -45,6 +45,23 @@ include("../helper/plain_logic_circuits.jl")
     @test_nowarn save_as_dot(circuit, "$tmp/temp.dot")
   end
 
+  mktempdir() do tmp
+    a = compile(PlainLogicCircuit, Lit(1))
+    t = compile(PlainLogicCircuit, true)
+    na = compile(PlainLogicCircuit, Lit(-1))
+    nb = compile(PlainLogicCircuit, Lit(-2))
+    a′ = compile(PlainLogicCircuit, Lit(1))
+    f = compile(PlainLogicCircuit, false)
+    na′ = compile(PlainLogicCircuit, Lit(-1))
+    nb′ = compile(PlainLogicCircuit, Lit(-2))
+    and1 = a & nb
+    and2 = na & t
+    and3 = a′ & f
+    and4 = na′ & nb′
+    or = disjoin(and1, and2, and3, and4)
+    @test_nowarn save_as_tex(or, "/tmp/temp.tex")
+  end
+
   # TODO add a test to load and save and load an .sdd file
   # currently we have no sdd+vtree in the model zoo to do this
 

--- a/test/LoadSave/circuit_saver_test.jl
+++ b/test/LoadSave/circuit_saver_test.jl
@@ -59,7 +59,8 @@ include("../helper/plain_logic_circuits.jl")
     and3 = a′ & f
     and4 = na′ & nb′
     or = disjoin(and1, and2, and3, and4)
-    @test_nowarn save_as_tex(or, "/tmp/temp.tex")
+    @test_nowarn save_as_tex(or, "$tmp/temp.tex")
+    @test_nowarn save_as_dot2tex(or, "$tmp/temp.tex")
   end
 
   # TODO add a test to load and save and load an .sdd file


### PR DESCRIPTION
This patch adds a function `save_as_tex` for generating a TikZ LaTeX representation of a circuit.

The function takes some optional arguments that regulate how the network is displayed (node separation, gate styling, labels for vertices or edges, etc), and implementing this for the Probabilistic part should be trivial (we only need to pass a dictionary containing the weights as argument).

---

I underestimated how difficult it is to draw a circuit with TikZ. It works (somewhat) well for small circuits:

```julia
using LogicCircuits

a, b = compile(PlainLogicCircuit, Lit(1)), compile(PlainLogicCircuit, Lit(2))
na, nb = compile(PlainLogicCircuit, Lit(-1)), compile(PlainLogicCircuit, Lit(-2))
a′, b′ = compile(PlainLogicCircuit, Lit(1)), compile(PlainLogicCircuit, Lit(2))
na′, nb′ = compile(PlainLogicCircuit, Lit(-1)), compile(PlainLogicCircuit, Lit(-2))
and1 = a & nb
and2 = na & b
and3 = a′ & b′
and4 = na′ & nb′
or = disjoin(and1, and2, and3, and4)
save_as_tex(or, "/tmp/example_1.tex")
```
![1595393887](https://user-images.githubusercontent.com/3943662/88136039-d79f7d80-cbbe-11ea-8afb-c3f49e4832a9.png)

But for larger circuits the problem of overlapping is obvious.

```julia
using LogicCircuits

⋀_1 = compile(PlainLogicCircuit, Lit(1)) & compile(PlainLogicCircuit, true)
⋀_2 = compile(PlainLogicCircuit, Lit(-1)) & compile(PlainLogicCircuit, Lit(-2))
⋀_3 = compile(PlainLogicCircuit, Lit(3)) & compile(PlainLogicCircuit, Lit(-4))
⋀_4 = compile(PlainLogicCircuit, Lit(-3)) & compile(PlainLogicCircuit, false)
⋀_5 = compile(PlainLogicCircuit, Lit(3)) & compile(PlainLogicCircuit, true)
⋀_6 = compile(PlainLogicCircuit, Lit(-3)) & compile(PlainLogicCircuit, Lit(4))
⋀_7 = compile(PlainLogicCircuit, Lit(1)) & compile(PlainLogicCircuit, Lit(2))
⋀_8 = compile(PlainLogicCircuit, true)
⋀_9 = compile(PlainLogicCircuit, Lit(-1)) & compile(PlainLogicCircuit, Lit(-2))
⋀_10 = compile(PlainLogicCircuit, false)

l = (⋀_1 | ⋀_2) & (⋀_3 | ⋀_4)
m = (⋀_5 | ⋀_6) & compile(PlainLogicCircuit, false)
r = (⋀_7 | ⋀_8) & (⋀_9 | ⋀_10)

ξ = disjoin(l, m, r)
save_as_tex(ξ, "/tmp/example_2.tex")
```
![1595393967](https://user-images.githubusercontent.com/3943662/88136135-04ec2b80-cbbf-11ea-9c37-868e5bc297ef.png)

Since the output `.tex` file is a human-readable file, it can be used to generate a rough sketch of the circuit and eventually tweaked to actually look good.

Suggestions on how to make this better are very welcome.