### PR TITLE
Optionally pass an IO instead of filename to vtree saving

### DIFF
--- a/src/LoadSave/circuit_savers.jl
+++ b/src/LoadSave/circuit_savers.jl
@@ -4,11 +4,15 @@ export save_as_dot, save_circuit, save_as_sdd, save_as_tex, save_as_dot2tex, sav
 # Save lines
 #####################
 
-function save_lines(name::String, lines::CircuitFormatLines)
-    open(name, "w") do f
-        for line in lines
-            println(f, line)
+function save_lines(file::Union{String, IO}, lines::CircuitFormatLines)
+    if file isa String
+        open(file, "w") do f
+            for line in lines
+                println(f, line)
+            end
         end
+    else
+        for line in lines println(file, line) end
     end
 end
 

--- a/src/LoadSave/vtree_loaders.jl
+++ b/src/LoadSave/vtree_loaders.jl
@@ -5,7 +5,7 @@ export load_vtree, zoo_vtree, zoo_vtree_file
 
 Load a vtree file from file. Currently only supports ".vtree" format.
 """
-function load_vtree(file::String, ::Type{V}=PlainVtree)::V where V<:Vtree
+function load_vtree(file::Union{String, IO}, ::Type{V}=PlainVtree)::V where V<:Vtree
     return compile_vtree_format_lines(parse_vtree_file(file), V)
 end
 
@@ -41,22 +41,22 @@ function parse_vtree_header_line(ln::String)
     VtreeHeaderLine()
 end
 
-function parse_vtree_file(file::String)::VtreeFormatLines
+function parse_vtree_file(file::Union{String, IO})::VtreeFormatLines
     q = Vector{VtreeFormatLine}()
-    open(file) do file
-        for ln in eachline(file)
-            if ln[1] == 'c'
-                push!(q, parse_vtree_comment_line(ln))
-            elseif ln[1] == 'L'
-                push!(q, parse_vtree_leaf_line(ln))
-            elseif ln[1] == 'I'
-                push!(q, parse_vtree_inner_line(ln))
-            elseif startswith(ln, "vtree")
-                push!(q, parse_vtree_header_line(ln))
-            else
-                error("Don't know how to parse vtree file format line $ln")
-            end
+    if file isa String file = open(file) end
+    for ln in eachline(file)
+        if ln[1] == 'c'
+            push!(q, parse_vtree_comment_line(ln))
+        elseif ln[1] == 'L'
+            push!(q, parse_vtree_leaf_line(ln))
+        elseif ln[1] == 'I'
+            push!(q, parse_vtree_inner_line(ln))
+        elseif startswith(ln, "vtree")
+            push!(q, parse_vtree_header_line(ln))
+        else
+            error("Don't know how to parse vtree file format line $ln")
         end
     end
+    close(file)
     q
 end

--- a/test/LoadSave/vtree_parser_test.jl
+++ b/test/LoadSave/vtree_parser_test.jl
@@ -33,16 +33,25 @@
         temp_path = "$tmp/little_4var_temp.vtree"
         save_vtree(temp_path, vtree)
 
-        # load it from file, and then run the same tests
-        vtree2 = load_vtree(temp_path)
-        test_vtree(vtree2)
-        @test vtree == vtree2 # we can test equality of plain vtrees!
+        # Save vtree from existing file stream
+        temp_stream = open("$tmp/little_4var_temp_stream.vtree", "w")
+        save_vtree(temp_stream, vtree)
+        close(temp_stream)
+
+        # load from file, and then run the same tests
+        temp_stream = open("$tmp/little_4var_temp_stream.vtree", "r")
+        for f in [temp_path, temp_stream]
+            vtree2 = load_vtree(f)
+            test_vtree(vtree2)
+            @test vtree == vtree2 # we can test equality of plain vtrees!
+        end
+        close(temp_stream)
 
         # Save dot file
         dot_path = "$tmp/little_4var_temp.dot"
         save_vtree(dot_path, vtree)
 
-        # Save unsupported format 
+        # Save unsupported format
         dot_path = "$tmp/little_4var_temp.bad_extension"
         @test_throws String save_vtree(dot_path, vtree)
     end


### PR DESCRIPTION
Hi,

I'm working on ensemble of PSDDs, and to make life easier I decided to save ensembles as zip files with `.psdd` and `.vtree` files in them. The current versions of LogicCircuits and ProbabilisticCircuits don't let you pass an `IO`, making you use the filename instead. The way `ZipFile` (https://github.com/fhs/ZipFile.jl/blob/master/src/ZipFile.jl) is implemented, I'd need to pass an IO instead. This PR gives saving/loading more flexibility by allowing you to alternatively pass an `IO`. I added a few tests just to make sure I didn't break anything and they're all green. :)

Thanks,
Renato