### PR TITLE
Structured smoothing

### DIFF
--- a/src/LogicCircuits.jl
+++ b/src/LogicCircuits.jl
@@ -11,12 +11,13 @@ include("abstract_logic_nodes.jl")
 include("bit_circuit.jl")
 include("queries.jl")
 include("satisfies_flow.jl")
-include("transformations.jl")
 include("plain_logic_nodes.jl")
 
 include("structured/abstract_vtrees.jl")
 include("structured/plain_vtrees.jl")
 include("structured/structured_logic_nodes.jl")
+
+include("transformations.jl")
 
 include("sdd/sdds.jl")
 include("sdd/sdd_functions.jl")

--- a/src/Utils/trees.jl
+++ b/src/Utils/trees.jl
@@ -57,6 +57,7 @@ lca(::Nothing, v::Tree, ::Function)::Tree = v
 lca(v::Tree, ::Nothing, ::Function)::Tree = v
 lca(::Nothing, ::Nothing, ::Function)::Nothing = nothing
 lca(v::Tree, w::Tree, u::Tree, r::Tree...) = lca(lca(v,w), u, r...)
+lca(v::Tree)::Tree = v
 
 "Find the leaf in the tree by follwing the branching function"
 find_leaf(n::Tree, branch::Function) = find_leaf(n, NodeType(n), branch)

--- a/src/queries.jl
+++ b/src/queries.jl
@@ -333,9 +333,11 @@ const Signature = Vector{Rational{BigInt}}
 Get a signature for each node using probabilistic equivalence checking.
 Note that this implentation may not have any formal guarantees as such.
 """
-function prob_equiv_signature(circuit::LogicCircuit, k::Int)::Dict{Union{Var,Node},Signature}
+function prob_equiv_signature(circuit::LogicCircuit, k::Int, signs=Dict{Union{Var,Node},Signature}())::Dict{Union{Var,Node},Signature}
     # uses probability instead of integers to circumvent smoothing, no mod though
-    signs::Dict{Union{Var,Node},Signature} = Dict{Union{Var,Node},Signature}()
+    if signs === nothing
+        signs = Dict{Union{Var,Node},Signature}()
+    end
     prime::Int = 7919 #TODO set as smallest prime larger than num_variables
     randprob() = BigInt(1) .// rand(1:prime,k)
     do_signs(v::Var) = get!(randprob, signs, v)

--- a/src/queries.jl
+++ b/src/queries.jl
@@ -250,7 +250,9 @@ function implied_literals_rec(root::LogicCircuit, lcache::Dict{LogicCircuit, Uni
         lcache[root] = BitSet([literal(root)])
     elseif isinnergate(root)
         for c in root.children
-            implied_literals_rec(c, lcache)
+            if !haskey(lcache, c)
+                implied_literals_rec(c, lcache)
+            end
         end
         if is⋀gate(root)
             # If there's a false in here then this is false too

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -13,6 +13,11 @@ export smooth, forget, propagate_constants, deepcopy, condition, replace_node,
 Create an equivalent smooth circuit from the given circuit.
 """
 function smooth(root::StructLogicCircuit)::StructLogicCircuit
+    (false_node, true_node) = canonical_constants(root)
+    if !(false_node === nothing && true_node === nothing)
+        @throw("You should propagate constants before smoothing a structured circuit!")
+    end
+
     lit_nodes = canonical_literals(root)
     f_con(n) = (n, BitSet())
     f_lit(n) = (n, BitSet(variable(n)))
@@ -73,7 +78,7 @@ end
 
 
 """
-    smooth_node(node::Node, missing_scope, lit_nodes)
+    smooth_node(node::StructLogicCircuit, missing_scope, lit_nodes)
 
 Return a smooth version of the node where 
 the `missing_scope` variables are added to the scope, using literals from `lit_nodes`

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -3,67 +3,28 @@ export smooth, forget, propagate_constants, deepcopy, condition, replace_node,
     clone_candidates, standardize_circuit, collapse_ands
 
 
-# include("structured/abstract_vtrees.jl") # and these
-# include("structured/plain_vtrees.jl")
-# include("structured/structured_logic_nodes.jl") # Fix this
-
 """
     smooth(root::StructLogicCircuit)::StructLogicCircuit
     
 Create an equivalent smooth circuit from the given circuit.
 """
 function smooth(root::StructLogicCircuit)::StructLogicCircuit
-    # (false_node, true_node) = canonical_constants(root)
-    # if !(false_node === nothing && true_node === nothing)
-    #     throw("You should propagate constants before smoothing a structured circuit!")
-    # end
+    (false_node, true_node) = canonical_constants(root)
+    @assert (false_node === nothing && true_node === nothing) "You should propagate constants before smoothing a structured circuit!"
 
     lit_nodes = canonical_literals(root)
     f_con(n) = (n, BitSet())
     f_lit(n) = (n, BitSet(variable(n)))
     f_a(n, call) = begin
-        # parent_scope = BitSet()
-        # smooth_children = Vector{Node}(undef, num_children(n))
-        # child_vtrs = []
-        # child_actual_vtrs = []
-        # child_types = []
         (prime, pscope) = call(n.prime)
-        # Edge case for leaves
-        # if isliteralgate(prime)
-            @show prime = fill_missing_vtree(prime, vtree(n).left, vtree(prime), lit_nodes)
-            pscope = variables(vtree(n).left)
-        # end
-        @show pscope
-        @show vtree(prime)
-        @show vtree(n).left
+        prime = fill_missing_vtree(prime, vtree(n).left, vtree(prime), lit_nodes)
+        pscope = variables(vtree(n).left)
         (sub, sscope) = call(n.sub)
-        # if isliteralgate(sub)
-            @show sub = fill_missing_vtree(sub, vtree(n).right, vtree(sub), lit_nodes)
-            sscope = variables(vtree(n).right)
-        # end
-        @show sscope
-        @show vtree(sub)
-        @show vtree(n).right
+        sub = fill_missing_vtree(sub, vtree(n).right, vtree(sub), lit_nodes)
+        sscope = variables(vtree(n).right)
+
         parent_scope = pscope ∪ sscope
         smoothed = conjoin([prime, sub])
-        # map!(smooth_children, children(n)) do child
-        #     (smooth_child, scope) = call(child)
-        #     push!(child_vtrs, lca(map(x -> vtree(lit_nodes[x]), collect(scope))...))
-        #     push!(child_actual_vtrs, variables(vtree(smooth_child)))
-        #     push!(child_types, typeof(smooth_child))
-        #     union!(parent_scope, scope)
-        #     smooth_child
-        # end
-        # vtr = lca(map(x -> vtree(lit_nodes[x]), collect(parent_scope))...)
-        # smoothed = conjoin([smooth_children...]; use_vtree=vtr)
-        # We should now be at the "correct" lowest possible vtree node
-        @show curr_vtr = vtree(n)
-        # @show child_vtrs
-        # @show child_actual_vtrs
-        # @show child_types
-        @show vtree(smoothed)
-        @show parent_scope
-        @show lca(map(x -> vtree(lit_nodes[x]), collect(parent_scope))...)
         @assert variables(vtree(smoothed)) == parent_scope
         (smoothed, parent_scope)
     end
@@ -102,7 +63,7 @@ function smooth(root::Node)::Node
         smooth_children = Vector{Node}(undef, num_children(n))
         map!(smooth_children, children(n)) do child
             (smooth_child, scope) = call(child)
-            smooth_node(smooth_child, setdiff(parent_scope, scope), scope, lit_nodes)
+            smooth_node(smooth_child, setdiff(parent_scope, scope), lit_nodes)
         end
         return (disjoin([smooth_children...]; reuse=n), parent_scope)
     end
@@ -111,17 +72,15 @@ end
 
 
 """
-    smooth_node(node::StructLogicCircuit, missing_scope, lit_nodes)
+    smooth_node(node::StructLogicCircuit, parent_scope, scope, lit_nodes)
 
 Return a smooth version of the node where 
-the `missing_scope` variables are added to the scope, using literals from `lit_nodes`
+the are added to the scope by filling the gap in vtrees, using literals from `lit_nodes`
 """
 function smooth_node(node::StructLogicCircuit, parent_scope, scope, lit_nodes)
-    vtr = vtree(node)
-    # Compute the node we're actually at based on variables used
-    @show target_vtr = lca(map(x -> vtree(lit_nodes[x]), collect(parent_scope))...)
-    @show curr_vtr = lca(map(x -> vtree(lit_nodes[x]), collect(scope))...)
-    @show vtr
+    # Compute the vtrees based on variables used
+    target_vtr = lca(map(x -> vtree(lit_nodes[x]), collect(parent_scope))...)
+    curr_vtr = lca(map(x -> vtree(lit_nodes[x]), collect(scope))...)
     if curr_vtr == target_vtr
         @assert isempty(setdiff(parent_scope, scope))
         node # If the node is where it should be on the vtree, we're done

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -1,6 +1,6 @@
 export smooth, forget, propagate_constants, deepcopy, condition, replace_node, 
     split, clone, merge, split_candidates, random_split, split_step, struct_learn,
-    clone_candidates, standardize_circuit, collapse_ands
+    clone_candidates, standardize_circuit
 
 
 """

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -15,7 +15,7 @@ Create an equivalent smooth circuit from the given circuit.
 function smooth(root::StructLogicCircuit)::StructLogicCircuit
     (false_node, true_node) = canonical_constants(root)
     if !(false_node === nothing && true_node === nothing)
-        @throw("You should propagate constants before smoothing a structured circuit!")
+        throw("You should propagate constants before smoothing a structured circuit!")
     end
 
     lit_nodes = canonical_literals(root)

--- a/test/transformations_test.jl
+++ b/test/transformations_test.jl
@@ -26,6 +26,7 @@ end
     @test !issmooth(sdd)
     @test issmooth(slc)
     @test issmooth(sstructplc)
+    @test respects_vtree(sstructplc, vtr)
 
     e1 = prob_equiv_signature(slc, 3)
     e2 = prob_equiv_signature(sstructplc, 3, e1)

--- a/test/transformations_test.jl
+++ b/test/transformations_test.jl
@@ -15,6 +15,23 @@ include("helper/plain_logic_circuits.jl")
     end
 end
 
+@testset "Structured smooth test" begin
+    sdd = zoo_sdd("random.sdd")
+    vtr = zoo_vtree("random.vtree")
+    slc = smooth(sdd)
+    plc = propagate_constants(sdd, remove_unary=true)
+    structplc = compile(StructLogicCircuit, vtr, plc) 
+    sstructplc = smooth(structplc)
+
+    @test !issmooth(sdd)
+    @test issmooth(slc)
+    @test issmooth(sstructplc)
+
+    e1 = prob_equiv_signature(slc, 3)
+    e2 = prob_equiv_signature(sstructplc, 3, e1)
+    @test e1[slc] == e2[sstructplc]
+end
+
 @testset "Forget test" begin
     for file in [zoo_sdd_file("random.sdd")] #  save some test time;zoo_psdd_file("plants.psdd"),
         c1 = load_logic_circuit(file)


### PR DESCRIPTION
This adds smoothing for structured logic circuits, respecting the current vtree. Appears to be working - looking for more example tests that don't have dependencies in Probabilistic circuits.
I couldn't find a way around doing work at both AND and OR nodes, it's possible there is some unnecessary work going on.
As of right now this will only work on *logic* circuits due to typing issues. A future pr should add a "structured decomposable" trait which would allow this to work with structured prob nodes as well.