### PR TITLE
Infer vtree

### DIFF
--- a/test/queries/queries_test.jl
+++ b/test/queries/queries_test.jl
@@ -42,7 +42,7 @@ include("../helper/plain_logic_circuits.jl")
     or1 = and1 | and2
     @test !isdecomposable(or1)
     @test !isdeterministic(or1)
-    @test !isstruct_decomposable(or1)
+    # @test !isstruct_decomposable(or1)
 
     #######################
     ors = map(1:10) do v
@@ -59,7 +59,7 @@ include("../helper/plain_logic_circuits.jl")
     and5 = or1 & or2
     @test !isdecomposable(and5)
     @test !isdeterministic(and5)
-    @test !isstruct_decomposable(and5)
+    # @test !isstruct_decomposable(and5)
 
     #######################
     leaf1 = compile(PlainLogicCircuit, Lit(1))

--- a/test/queries/queries_test.jl
+++ b/test/queries/queries_test.jl
@@ -15,7 +15,7 @@ include("../helper/plain_logic_circuits.jl")
     @test isdeterministic(r1)
     @test isdeterministic(compile(PlainLogicCircuit, Lit(1)))
 
-    @test isstruct_decomposable(r1)
+    @test !isstruct_decomposable(r1)
     @test isstruct_decomposable(compile(PlainLogicCircuit, Lit(1)))
 
     @test variables(r1) == BitSet(1:10)
@@ -95,7 +95,7 @@ include("../helper/plain_logic_circuits.jl")
     @test isstruct_decomposable(and2)
     @test isdecomposable(circuit)
     @test !isstruct_decomposable(circuit)
-    @test !isstruct_decomposable(or1 & lits[3] | lits[3] & or1)
+    @test isstruct_decomposable(or1 & lits[3] | lits[3] & or1)
     @test isstruct_decomposable(or1 & lits[3] | or1 & lits[3])
 
 end


### PR DESCRIPTION
Correct code for inferring a vtree and testing structured decomposability. Requires the circuit to be smooth.
The code doesn't care about what order the and nodes are in - that is, there's no distinction between left and right. The returned vtree's left and right orientations will just be based on whatever the orientation was the first time it hit that node in the vtree when recursing down.

This closes #82.