### PR TITLE
Upgrade to dataframes 1.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TikzGraphs = "b4f28e30-c73f-5eaf-a395-8a9db949a742"
 
 [compat]

--- a/src/LoadSave/data_loaders.jl
+++ b/src/LoadSave/data_loaders.jl
@@ -33,9 +33,9 @@ function process_mnist(MLDS_MNIST, labeled = false)
     train_x = collect(Float32, transpose(reshape(MLDS_MNIST.traintensor(), 28*28, :)))
     test_x  = collect(Float32, transpose(reshape(MLDS_MNIST.testtensor(), 28*28, :)))
     
-    train = DataFrame(train_x)
+    train = DataFrame(train_x, :auto)
     valid = nothing # why is there no validation set in `MLDataSets`??
-    test = DataFrame(test_x)
+    test = DataFrame(test_x, :auto)
     if (labeled)
         train_y::Vector{UInt8} = MNIST.trainlabels()
         test_y::Vector{UInt8}  = MNIST.testlabels()
@@ -59,8 +59,11 @@ function twenty_datasets(name)
     function load(type)
         dataframe = CSV.read(data_dir*"/Density-Estimation-Datasets-1.0.1/datasets/$name/$name.$type.data", DataFrame; 
             header=false, truestrings=["1"], falsestrings=["0"], type=Bool, strict=true)
-                 # make sure the data is backed by a `BitArray`
-        DataFrame((BitArray(Base.convert(Matrix{Bool}, dataframe))))
+        
+        # make sure the data is backed by a `BitArray`
+        # TODO not sure if this is works [cannot use the previous version in DataFrames 1.x]
+        df = DataFrame(BitArray(Tables.matrix(dataframe)), :auto)
+        rename!(df, names(dataframe))
     end
     train = load("train")
     valid = load("valid")

--- a/src/queries/satisfies.jl
+++ b/src/queries/satisfies.jl
@@ -19,10 +19,10 @@ satisfies(root::LogicCircuit, data::Real...) =
     
 
 satisfies(root::LogicCircuit, data::AbstractVector{Bool}) =
-    satisfies(root, DataFrame(Tables.table(reshape(BitVector(data), 1, :))))[1]
+    satisfies(root, DataFrame(reshape(BitVector(data), 1, :), :auto))[1]
 
 satisfies(root::LogicCircuit, data::AbstractVector{<:AbstractFloat}) =
-    satisfies(root, DataFrame(reshape(data, 1, :)))[1]
+    satisfies(root, DataFrame(reshape(data, 1, :), :auto))[1]
 
 satisfies(circuit::LogicCircuit, data::DataFrame) =
     satisfies(same_device(BitCircuit(circuit, data), data) , data)

--- a/src/queries/satisfies_flow.jl
+++ b/src/queries/satisfies_flow.jl
@@ -8,7 +8,7 @@ export model_var_prob, satisfies_flows_down, satisfies_flows, count_downflow, do
 "Compute the probability of each variable for a random satisfying assignment of the logical circuit"
 function model_var_prob(root::LogicCircuit)
     nvars = num_variables(root)
-    v, f, _ = satisfies_flows(root, DataFrame(fill(0.5, 1, nvars)))
+    v, f, _ = satisfies_flows(root, DataFrame(fill(0.5, 1, nvars), :auto))
     f[3:2+nvars]./v[end]
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -13,6 +13,5 @@ Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-DataFrames = "0.21"
 Jive = "0.2"
 Suppressor = "0.2"

--- a/test/Utils/data_test.jl
+++ b/test/Utils/data_test.jl
@@ -6,8 +6,8 @@ using CUDA: CUDA
 @testset "Data utils" begin
 
     m = [1.1 2.1; 3.1 4.1; 5.1 6.1]
-    df = DataFrame(m)
-    dfb = DataFrame(BitMatrix([true false; true true; false true]))
+    df = DataFrame(m, :auto)
+    dfb = DataFrame(BitMatrix([true false; true true; false true]), :auto)
     
     batched_df = batch(df, 1)
     batched_dfb = batch(dfb, 1)
@@ -34,7 +34,7 @@ using CUDA: CUDA
     @test !isfpdata(dfb)
     @test isfpdata(batched_df)
     @test !isfpdata(batched_dfb)
-    @test !isfpdata(DataFrame([1 "2"; 3 "4"]))
+    @test !isfpdata(DataFrame([1 "2"; 3 "4"], :auto))
 
     @test !isbinarydata(df)
     @test isbinarydata(dfb)
@@ -55,7 +55,7 @@ using CUDA: CUDA
 
     @test bits_per_pixel(-12.3, dfb) ≈ 2.9575248338223754 #not verified
     
-    dfb = DataFrame(BitMatrix([true false; true true; false true]))
+    dfb = DataFrame(BitMatrix([true false; true true; false true]), :auto)
     
     @test !isweighted(dfb)
     
@@ -72,7 +72,7 @@ using CUDA: CUDA
     @test isweighted(wdfb2)
     @test !isweighted(dfb_split1)
     
-    dataset = DataFrame([true false false; true true true; false false true; false true false])
+    dataset = DataFrame([true false false; true true true; false false true; false true false], :auto)
     weights = [0.6, 0.6, 0.6, 0.8]
     dataset = weigh_samples(dataset, weights)
     bag_datasets = bagging_dataset(dataset; num_bags = 5, frac_examples = 1.0);
@@ -86,7 +86,7 @@ using CUDA: CUDA
     @test length(bag_datasets[1]) == 4
     @test ncol(bag_datasets[1][1]) == ncol(dataset) - 1
     
-    df = DataFrame(BitMatrix([true true; false true; false false]))
+    df = DataFrame(BitMatrix([true true; false true; false false]), :auto)
     mar = marginal_prob(df)
     @test mar[1] ≈ 0.333333333 atol = 1e-6
     @test mar[2] ≈ 0.666666666 atol = 1e-6
@@ -119,7 +119,7 @@ using CUDA: CUDA
         @test isgpu(to_gpu(wdfb1_gpu))
     end
     
-    df = DataFrame(Matrix{Union{Bool,Missing}}([true missing; missing false]))
+    df = DataFrame(Matrix{Union{Bool,Missing}}([true missing; missing false]), :auto)
     sdf = soften(df, 0.01; scale_by_marginal = false)
     @test sdf[1,1] ≈ 0.99 atol = 1e-6
     @test ismissing(sdf[1,2])

--- a/test/Utils/misc_test.jl
+++ b/test/Utils/misc_test.jl
@@ -71,7 +71,7 @@ end
          2.0 1.0;
          5.0 10.0;
          ]
-    df = DataFrame(m)
+    df = DataFrame(m, :auto)
     dfb = DataFrame(BitMatrix([true false true; 
                                true true true; 
                                false true true;
@@ -79,7 +79,7 @@ end
                                false false false;
                                true false true;
                                false false true;
-                            ]))
+                            ]), :auto)
 
     all_missing = make_missing_mcar(df; keep_prob=0.0)
     @test all(ismissing.(Matrix(all_missing)))

--- a/test/queries/satisfies_flow_test.jl
+++ b/test/queries/satisfies_flow_test.jl
@@ -13,7 +13,7 @@ include("../helper/gpu.jl")
             0 0 0 0 0 0 0 0 0 0;
             0 1 1 0 1 0 0 1 0 1]
 
-    input = DataFrame(BitArray(input))
+    input = DataFrame(BitArray(input), :auto)
     @test r(input) == BitVector([1,1,1,1])
 
     vtree = PlainVtree(10, :balanced)
@@ -41,7 +41,7 @@ include("../helper/gpu.jl")
         (v[2] | !v[7] | v[6]) &
         (v[3] | !v[4] | v[5]) &
         (v[1] | !v[4] | v[6])
-    input = DataFrame(bitrand(25,num_vars))
+    input = DataFrame(bitrand(25,num_vars), :auto)
     
     r = smooth(PlainLogicCircuit(c)) # flows don't make sense unless the circuit is smooth; cannot smooth trimmed SDDs
 
@@ -64,7 +64,7 @@ include("../helper/gpu.jl")
     l3 = LogicCircuit(Lit(-1))
     l4 = LogicCircuit(Lit(-2))
     r = (l1 & l2) | (l3 & l4)
-    input = DataFrame(bitrand(4,2))
+    input = DataFrame(bitrand(4,2), :auto)
 
     v, f, node2id = satisfies_flows(r, input)
     foreach(literal_nodes(r)) do n
@@ -91,7 +91,7 @@ end
             0 0 0 0 0 0 0 0 0 0;
             0 1 1 0 1 0 0 1 0 1]
 
-    input = DataFrame(BitArray(input))
+    input = DataFrame(BitArray(input), :auto)
     @test r(input) == BitVector([1,1,1,1])
     
     weights = [0.6, 0.6, 0.6, 0.6]
@@ -120,7 +120,7 @@ end
         (v[2] | !v[7] | v[6]) &
         (v[3] | !v[4] | v[5]) &
         (v[1] | !v[4] | v[6])
-    input = DataFrame(bitrand(25,num_vars))
+    input = DataFrame(bitrand(25,num_vars), :auto)
     
     weights = Array{Float32, 1}(ones(25) * 0.6)
     
@@ -143,7 +143,7 @@ end
     l3 = LogicCircuit(Lit(-1))
     l4 = LogicCircuit(Lit(-2))
     r = (l1 & l2) | (l3 & l4)
-    input = DataFrame(bitrand(4,2))
+    input = DataFrame(bitrand(4,2), :auto)
 
     v, f, node2id = satisfies_flows(r, input; weights = weights)
     foreach(literal_nodes(r)) do n
@@ -173,7 +173,7 @@ end
     weights = [0.6, 0.6, 0.6]
     weights = Array{Float32, 1}(weights)
     
-    df = DataFrame(BitMatrix([true true; false true; false false]))
+    df = DataFrame(BitMatrix([true true; false true; false false]), :auto)
     sdf = soften(df, 0.001; scale_by_marginal = false)
     
     v, f, node2id = satisfies_flows(r, sdf)
@@ -201,7 +201,7 @@ end
     input = DataFrame(Float64[1 0 1 0 1 0 1 0 1 0;
                     1 1 1 1 1 1 1 1 1 1;
                     0 0 0 0 0 0 0 0 0 0;
-                    0 1 1 0 1 0 0 1 0 1])
+                    0 1 1 0 1 0 0 1 0 1], :auto)
 
     @test r(input) ≈ [1.0, 1.0, 1.0, 1.0]
 
@@ -230,7 +230,7 @@ end
     o_nc = (l_a & l_b & l_nc) | (l_a & l_nb & l_nc) | (l_na & l_b & l_nc) | (l_na & l_nb & l_nc)
     r = (o_c | o_nc)
 
-    input = DataFrame(rand(Float64, (10,3)))
+    input = DataFrame(rand(Float64, (10,3)), :auto)
 
     @test all(r(input) .≈ 1.0)
 
@@ -260,7 +260,7 @@ end
     o_nc = (l_a & l_nb & l_nc) | (l_na & l_nb & l_nc)
     r = (o_c | o_nc)
 
-    input = DataFrame(rand(Float64, (10,3)))
+    input = DataFrame(rand(Float64, (10,3)), :auto)
     input[1:5, 3] .= 0.0
 
     v, f, node2id = satisfies_flows(r, input)
@@ -291,9 +291,9 @@ end
     input_b = DataFrame(BitArray([1 0 1 0 1 0 1 0 1 0;
                     1 1 1 1 1 1 1 1 1 1;
                     0 0 0 0 0 0 0 0 0 0;
-                    0 1 1 0 1 0 0 1 0 1]))
+                    0 1 1 0 1 0 0 1 0 1]), :auto)
     
-    input_f = DataFrame(Float64.(Matrix(input_b)))
+    input_f = DataFrame(Float64.(Matrix(input_b)), :auto)
     
     f_b, v_b, node2id = satisfies_flows(r, input_b)
     f_f, v_f, node2id = satisfies_flows(r, input_f)
@@ -313,21 +313,21 @@ end
     input1 = DataFrame(BitArray([1 0 1 0 1 0 1 0 1 0;
                                 1 1 1 1 1 1 1 1 1 1;
                                 0 0 0 0 0 0 0 0 0 0;
-                                0 1 1 0 1 0 0 1 0 1]))
+                                0 1 1 0 1 0 0 1 0 1]), :auto)
 
     input2 = DataFrame(BitArray([0 1 1 1 0 1 1 1 0 0;
                                 1 1 0 0 1 1 0 1 0 1;
                                 1 0 0 0 1 0 1 0 1 0;
-                                0 0 1 1 0 1 1 0 0 1]))
+                                0 0 1 1 0 1 1 0 0 1]), :auto)
 
     input3 = DataFrame(BitArray([1 0 1 0 1 0 1 0 1 0;
                                 0 1 0 1 0 1 1 1 0 1;
                                 0 1 0 1 0 1 1 0 1 0;
-                                0 0 1 1 1 0 1 0 0 1]))
+                                0 0 1 1 1 0 1 0 0 1]), :auto)
     
     input4 = DataFrame(0.3 .* Float64.(Matrix(input1)) .+ 
                         0.1 .* Float64.(Matrix(input2)) .+ 
-                        0.6 .* Float64.(Matrix(input3)))
+                        0.6 .* Float64.(Matrix(input3)), :auto)
 
     inputs = [input1, input2, input3, input4]
     vfs = [satisfies_flows(r, input) for input in inputs]

--- a/test/structured/structured_logic_nodes_test.jl
+++ b/test/structured/structured_logic_nodes_test.jl
@@ -62,9 +62,9 @@ using DataFrames: DataFrame
     @test model_count(f) == BigInt(2)^10
 
     @test f(DataFrame(BitArray([1 0 1 0 1 0 1 0 1 0;
-                       1 1 1 1 1 1 1 1 1 1;
-                       0 0 0 0 0 0 0 0 0 0;
-                       0 1 1 0 1 0 0 1 0 1]))) == BitVector([1,1,1,1])
+                        1 1 1 1 1 1 1 1 1 1;
+                        0 0 0 0 0 0 0 0 0 0;
+                        0 1 1 0 1 0 0 1 0 1]), :auto)) == BitVector([1,1,1,1])
 
     plainf = PlainLogicCircuit(f) 
     foreach(plainf) do n


### PR DESCRIPTION
Biggest changes are:

1. Cannot do `DataFrame(matrix)` anymore, and need to either do `DataFrame(matrix, :auto)` or `DataFrame(Tables.table(matrix))`.

2. Cannot use `Base.convert`  for converting DataFrame to matrix, should use `Tables.matrix(dataframe)` instead.

