### PR TITLE
Fix BDDs overwriting LoadSave.load_cnf

### DIFF
--- a/src/bdd/bdds.jl
+++ b/src/bdd/bdds.jl
@@ -957,7 +957,7 @@ end
 export save_bdd
 
 "Loads a CNF as a BDD. Use `load` instead."
-function load_cnf(::Type{Bdd}, filename::String; kwargs...)::Bdd
+function LoadSave.load_cnf(::Type{Bdd}, filename::String; kwargs...)::Bdd
   ϕ = ⊤
   open(filename, "r"; kwargs...) do input
     for line ∈ eachline(input)
@@ -971,7 +971,7 @@ function load_cnf(::Type{Bdd}, filename::String; kwargs...)::Bdd
 end
 
 "Loads a CNF as a BDD. Use `load` instead."
-function load_dnf(::Type{Bdd}, filename::String; kwargs...)::Bdd
+function LoadSave.load_dnf(::Type{Bdd}, filename::String; kwargs...)::Bdd
   ϕ = ⊥
   open(filename, "r"; kwargs...) do input
     for line ∈ eachline(input)


### PR DESCRIPTION
Hi,

This patch fixes an issue where `LoadSave.load_cnf` and `LoadSave.load_dnf` would be obscured by the BDD code introduced in #90.

Since the code is provisional until we fully integrate BDDs into LogicCircuits, I didn't move the code to `LoadSave` and instead extended the corresponding functions for BDDs. This will make it easier for late refactoring, since all BDD code will be in one place.

Thanks!