### PR TITLE
Allow empty lines in CNF files

### DIFF
--- a/src/LoadSave/circuit_loaders.jl
+++ b/src/LoadSave/circuit_loaders.jl
@@ -330,7 +330,7 @@ function load_cnf(file::String; dual=false)::PlainLogicCircuit
     open(file) do file
 
         for ln in eachline(file)
-            @assert !isempty(ln)
+            if isempty(ln) continue end
             if ln[1] == 'c' || 
                 !dual && startswith(ln, "p cnf") || 
                 dual && startswith(ln, "p dnf")


### PR DESCRIPTION
Hi,

This patch allows empty lines in CNF files. Previously, LogicCircuits would complain when a CNF had empty lines, even trailing ones like the one in the example below:

```
p cnf 4 3
1 -2 0
3 -4 0
1 -4 0

```

Since file format specifications for `.cnf` (and `.dnf`) don't specify that empty lines are disallowed, this patch removes such a requirement.

I considered having this patch as part of #96, but I didn't know whether this PR in particular would be accepted, so sending this out as separate. Sorry for the spam :)

Thanks!