### PR TITLE
Add `make_vars_contiguous` and `has_vars_contiguous` to relabel variable indices

### DIFF
--- a/src/abstract_logic_nodes.jl
+++ b/src/abstract_logic_nodes.jl
@@ -7,7 +7,7 @@ export LogicCircuit, GateType, InnerGate, LeafGate,
     fully_factorized_circuit, 
     ⋁_nodes, ⋀_nodes, or_nodes, and_nodes, 
     canonical_literals, canonical_constants, tree_formula_string,
-    isflat, iscnf, isdnf
+    isflat, iscnf, isdnf, has_vars_contiguous
 
 #####################
 # Abstract infrastructure for logic circuit nodes
@@ -250,3 +250,9 @@ isdnf(circuit) =
     is⋁gate(circuit) && all(children(circuit)) do clause
         is⋀gate(clause) && all(isliteralgate, children(clause))
     end
+
+"Does the circuit have a contiguously indexed set of variables"
+has_vars_contiguous(circuit) = begin
+    vars = variables(circuit)
+    (maximum(vars) == length(vars))
+end

--- a/src/io/nnf_io.jl
+++ b/src/io/nnf_io.jl
@@ -99,7 +99,7 @@ Base.read(io::IO, ::Type{PlainLogicCircuit}, ::NnfFormat) =
 function Base.write(io::IO, circuit::LogicCircuit, ::NnfFormat)
 
     labeling = label_nodes(circuit)
-    map!(x -> x-1, values(labeling)) # vtree nodes are 0-based indexed
+    map!(x -> x-1, values(labeling)) # nodes are 0-based indexed
 
     println(io, "nnf $(num_nodes(circuit)) $(num_edges(circuit)) $(num_variables(circuit))")
     foreach(circuit) do n

--- a/test/transformations_test.jl
+++ b/test/transformations_test.jl
@@ -268,3 +268,19 @@ end
     @test circuit.children[3].literal == Lit(3)
     @test circuit.children[4].literal == Lit(4)
 end
+
+@testset "Contiguous variable test" begin
+    c1  = zoo_sdd_random
+    @test has_vars_contiguous(c1)
+
+    c2 = forget(c1, isodd)
+    @test variables(c2) == BitSet(2:2:num_variables(c1))
+    @test !has_vars_contiguous(c2)
+
+    c3, bijection = make_vars_contiguous(c2)
+    @test num_nodes(c2) == num_nodes(c3)
+    @test num_edges(c2) == num_edges(c3)
+    @test has_vars_contiguous(c3)
+
+    @test make_vars_contiguous(c1)[1] === c1
+end


### PR DESCRIPTION
Avoids issue with gaps in the variable ids.